### PR TITLE
Remove unsafe stringcast, leading to garbage strings (especially for 127+ character strings)

### DIFF
--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -698,11 +698,31 @@ FAngelscriptBinds::FBind Bind_ImGui_Window_Utilities(FAngelscriptBinds::EOrder::
 	{
 		return ImGui::GetWindowHeight();
 	});
+#if IMGUI_VERSION_NUM <= 19000
 	FAngelscriptBinds::BindGlobalFunction("float32 GetWindowContentRegionWidth()",
 	[]() -> float
 	{
+
 		return ImGui::GetWindowContentRegionWidth();
+
 	});
+#else
+	FAngelscriptBinds::BindGlobalFunction("float32 GetWindowContentRegionWidth()",
+[]() -> float
+	{
+
+		return ImGui::GetWindowContentRegionMax().x - ImGui::GetWindowContentRegionMin().x;
+
+	});
+	FAngelscriptBinds::BindGlobalFunction("float32 GetContentRegionAvailWidth()",
+[]() -> float
+	{
+
+		return ImGui::GetContentRegionAvail().x;
+
+	});
+#endif
+	
 });
 
 FAngelscriptBinds::FBind Bind_ImGui_Window_Manipulation(FAngelscriptBinds::EOrder::Late, []
@@ -1655,7 +1675,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Tooltips(FAngelscriptBinds::EOrder::Late, []
 {
 	FAngelscriptBinds::FNamespace ImGuiNamespace("ImGui");
 	FAngelscriptBinds::BindGlobalFunction("bool BeginTooltip()",
-	[]() -> void
+	[]()
 	{
 		return ImGui::BeginTooltip();
 	});

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -1633,6 +1633,26 @@ FAngelscriptBinds::FBind Bind_ImGui_Tooltips(FAngelscriptBinds::EOrder::Late, []
 	});
 });
 
+FAngelscriptBinds::FBind Bind_ImGui_TreeNode(FAngelscriptBinds::EOrder::Late, []
+{
+	FAngelscriptBinds::FNamespace ImGuiNamespace("ImGui");
+	FAngelscriptBinds::BindGlobalFunction("bool TreeNode(const FString& Label)",
+	[](const FString& Label) -> bool
+	{
+		return ImGui::TreeNode(ToImGui(Label));
+	});
+	FAngelscriptBinds::BindGlobalFunction("bool TreeNodeEx(const FString& Label, EImGuiTreeNodeFlags Flags = EImGuiTreeNodeFlags::None)",
+	[](const FString& Label, const ImGuiTreeNodeFlags Flags) -> bool
+	{
+		return ImGui::TreeNodeEx(ToImGui(Label), Flags);
+	});
+	FAngelscriptBinds::BindGlobalFunction("void TreePop()",
+	[]() -> void
+	{
+		ImGui::TreePop();
+	});
+});
+
 FAngelscriptBinds::FBind Bind_ImGui_Popups(FAngelscriptBinds::EOrder::Late, []
 {
 	FAngelscriptBinds::FNamespace ImGuiNamespace("ImGui");

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -1842,6 +1842,31 @@ FAngelscriptBinds::FBind Bind_ImGui_Widget_InputUtilitiesKeyboard(FAngelscriptBi
 	});
 });
 
+FAngelscriptBinds::FBind Bind_ImGui_Style(FAngelscriptBinds::EOrder::Late, []
+{
+	FAngelscriptBinds::FNamespace ImGuiNamespace("ImGui");
+	FAngelscriptBinds::BindGlobalFunction("void PushStyleColor(EImGuiCol Idx, const FColor& Color)",
+	[](const ImGuiCol Idx, const FColor Color) {
+			ImGui::PushStyleColor(Idx, ToImGui(Color));
+	});
+	FAngelscriptBinds::BindGlobalFunction("void PopStyleColor(int32 Count = 1)",
+	[](const int32 Count) {
+		ImGui::PopStyleColor(Count);
+	});
+	FAngelscriptBinds::BindGlobalFunction("void PushStyleVar(EImGuiStyleVar idx, float32 val)",
+[](ImGuiStyleVar Idx, float Val) {
+		ImGui::PushStyleVar(Idx, Val);
+	});
+	FAngelscriptBinds::BindGlobalFunction("void PushStyleVar(EImGuiStyleVar idx, const FVector2f& val)",
+		[](ImGuiStyleVar Idx, const FVector2f& Val) {
+			ImGui::PushStyleVar(Idx, ToImGui(Val));
+		});
+	FAngelscriptBinds::BindGlobalFunction("void PopStyleVar(int32 Count = 1)",
+	[](const int32 Count) {
+		ImGui::PopStyleVar(Count);
+	});
+});
+
 FAngelscriptBinds::FBind Bind_ImGui_Widget_InputUtilitiesMouse(FAngelscriptBinds::EOrder::Late, []
 {
 	FAngelscriptBinds::FNamespace ImGuiNamespace("ImGui");

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -898,6 +898,21 @@ FAngelscriptBinds::FBind Bind_ImGui_Main_Widgets(FAngelscriptBinds::EOrder::Late
 	{
 		return ImGui::Checkbox(ToImGui(Label), &bValue);
 	});
+	FAngelscriptBinds::BindGlobalFunction("bool RadioButton(const FString& Label, bool bActive)",
+		[](const FString& Label, const bool bActive) -> bool
+	{
+		return ImGui::RadioButton(ToImGui(Label), bActive);
+	});
+	FAngelscriptBinds::BindGlobalFunction("bool RadioButton(const FString& Label, int32& Value, int32 ButtonValue)",
+		[](const FString& Label, int32& Value, const int32 ButtonValue) -> bool
+	{
+		return ImGui::RadioButton(ToImGui(Label), &Value, ButtonValue);
+	});
+	FAngelscriptBinds::BindGlobalFunction("bool ProgressBar(float32 Fraction, const FVector2f& Size = FVector2f(-1, 0), const FString& Overlay = \"\")",
+		[](const float Fraction, const FVector2f& Size, const FString& Overlay) -> void
+	{
+		ImGui::ProgressBar(Fraction, ToImGui(Size), ToImGui(Overlay));
+	});
 	FAngelscriptBinds::BindGlobalFunction("bool Bullet()",
 	[]() -> void
 	{

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -283,7 +283,7 @@ FAngelscriptBinds::FBind Bind_ImGuiDragDropFlags(FAngelscriptBinds::EOrder::Norm
 
 FAngelscriptBinds::FBind Bind_ImGuiKey(FAngelscriptBinds::EOrder::Normal, []
 {
-    IMGUI_ENUM(ImGuiKey, "Identifies a key");
+	IMGUI_ENUM(ImGuiKey, "Identifies a key");
 	IMGUI_ENUM_VALUE(ImGuiKey, None,);
 	IMGUI_ENUM_VALUE(ImGuiKey, Tab,);
 	IMGUI_ENUM_VALUE(ImGuiKey, LeftArrow,);
@@ -659,45 +659,45 @@ FAngelscriptBinds::FBind Bind_ImGui_Window_Utilities(FAngelscriptBinds::EOrder::
 {
 	FAngelscriptBinds::FNamespace ImGuiNamespace("ImGui");
 	FAngelscriptBinds::BindGlobalFunction("bool IsWindowAppearing()",
-    []() -> bool
-    {
-        return ImGui::IsWindowAppearing();
-    });
-    FAngelscriptBinds::BindGlobalFunction("bool IsWindowCollapsed()",
-    []() -> bool
-    {
-        return ImGui::IsWindowCollapsed();
-    });
-    FAngelscriptBinds::BindGlobalFunction("bool IsWindowFocused(EImGuiFocusedFlags flags = EImGuiFocusedFlags::None)",
-    [](ImGuiFocusedFlags Flags) -> bool
-    {
-        return ImGui::IsWindowFocused(Flags);
-    });
-    FAngelscriptBinds::BindGlobalFunction("bool IsWindowHovered(EImGuiHoveredFlags flags = EImGuiFocusedFlags::None)",
-    [](ImGuiFocusedFlags Flags) -> bool
-    {
-        return ImGui::IsWindowHovered(Flags);
-    });
-    FAngelscriptBinds::BindGlobalFunction("FVector2f GetWindowPos()",
-    []() -> FVector2f
-    {
-        return ToUnreal(ImGui::GetWindowPos());
-    });
-    FAngelscriptBinds::BindGlobalFunction("FVector2f GetWindowSize()",
-    []() -> FVector2f
-    {
-        return ToUnreal(ImGui::GetWindowSize());
-    });
-    FAngelscriptBinds::BindGlobalFunction("float32 GetWindowWidth()",
-    []() -> float
-    {
-        return ImGui::GetWindowWidth();
-    });
-    FAngelscriptBinds::BindGlobalFunction("float32 GetWindowHeight()",
-    []() -> float
-    {
-        return ImGui::GetWindowHeight();
-    });
+	[]() -> bool
+	{
+		return ImGui::IsWindowAppearing();
+	});
+	FAngelscriptBinds::BindGlobalFunction("bool IsWindowCollapsed()",
+	[]() -> bool
+	{
+		return ImGui::IsWindowCollapsed();
+	});
+	FAngelscriptBinds::BindGlobalFunction("bool IsWindowFocused(EImGuiFocusedFlags flags = EImGuiFocusedFlags::None)",
+	[](ImGuiFocusedFlags Flags) -> bool
+	{
+		return ImGui::IsWindowFocused(Flags);
+	});
+	FAngelscriptBinds::BindGlobalFunction("bool IsWindowHovered(EImGuiHoveredFlags flags = EImGuiFocusedFlags::None)",
+	[](ImGuiFocusedFlags Flags) -> bool
+	{
+		return ImGui::IsWindowHovered(Flags);
+	});
+	FAngelscriptBinds::BindGlobalFunction("FVector2f GetWindowPos()",
+	[]() -> FVector2f
+	{
+		return ToUnreal(ImGui::GetWindowPos());
+	});
+	FAngelscriptBinds::BindGlobalFunction("FVector2f GetWindowSize()",
+	[]() -> FVector2f
+	{
+		return ToUnreal(ImGui::GetWindowSize());
+	});
+	FAngelscriptBinds::BindGlobalFunction("float32 GetWindowWidth()",
+	[]() -> float
+	{
+		return ImGui::GetWindowWidth();
+	});
+	FAngelscriptBinds::BindGlobalFunction("float32 GetWindowHeight()",
+	[]() -> float
+	{
+		return ImGui::GetWindowHeight();
+	});
 	FAngelscriptBinds::BindGlobalFunction("float32 GetWindowContentRegionWidth()",
 	[]() -> float
 	{
@@ -924,17 +924,17 @@ FAngelscriptBinds::FBind Bind_ImGui_Main_Widgets(FAngelscriptBinds::EOrder::Late
 		return ImGui::Checkbox(ToImGui(Label), &bValue);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool RadioButton(const FString& Label, bool bActive)",
-		[](const FString& Label, const bool bActive) -> bool
+	[](const FString& Label, const bool bActive) -> bool
 	{
 		return ImGui::RadioButton(ToImGui(Label), bActive);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool RadioButton(const FString& Label, int32& Value, int32 ButtonValue)",
-		[](const FString& Label, int32& Value, const int32 ButtonValue) -> bool
+	[](const FString& Label, int32& Value, const int32 ButtonValue) -> bool
 	{
 		return ImGui::RadioButton(ToImGui(Label), &Value, ButtonValue);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool ProgressBar(float32 Fraction, const FVector2f& Size = FVector2f(-1, 0), const FString& Overlay = \"\")",
-		[](const float Fraction, const FVector2f& Size, const FString& Overlay) -> void
+	[](const float Fraction, const FVector2f& Size, const FString& Overlay) -> void
 	{
 		ImGui::ProgressBar(Fraction, ToImGui(Size), ToImGui(Overlay));
 	});
@@ -1391,8 +1391,7 @@ FAngelscriptBinds::FBind Bind_ImGui_InputText(FAngelscriptBinds::EOrder::Late, [
 			{
 				FCStringAnsi::Strncpy(Array.GetData(), TCHAR_TO_UTF8(*Buffer), Array.Num());
 			}
-			return ImGui::InputText(ToImGui(Label), Array.GetData(), Array.Num(), Flags,
-	[](ImGuiInputTextCallbackData* Data)
+			return ImGui::InputText(ToImGui(Label), Array.GetData(), Array.Num(), Flags, [](ImGuiInputTextCallbackData* Data)
 			{
 				*static_cast<FString*>(Data->UserData) = FString(UTF8_TO_TCHAR(Data->Buf));
 				return 0;
@@ -1828,71 +1827,71 @@ FAngelscriptBinds::FBind Bind_ImGui_Widget_Utilities(FAngelscriptBinds::EOrder::
 	FAngelscriptBinds::FNamespace ImGuiNamespace("ImGui");
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemHovered(EImGuiHoveredFlags Flags = EImGuiHoveredFlags::None)",
 	[](const ImGuiHoveredFlags Flags) -> bool {
-	    return ImGui::IsItemHovered(Flags);
+		return ImGui::IsItemHovered(Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemActive()",
 	[]() -> bool {
-	    return ImGui::IsItemActive();
+		return ImGui::IsItemActive();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemFocused()",
 	[]() -> bool {
-	    return ImGui::IsItemFocused();
+		return ImGui::IsItemFocused();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemClicked(EImGuiMouseButton MouseButton = EImGuiMouseButton::Left)",
 	[](const ImGuiMouseButton MouseButton) -> bool {
-	    return ImGui::IsItemClicked(MouseButton);
+		return ImGui::IsItemClicked(MouseButton);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemVisible()",
 	[]() -> bool {
-	    return ImGui::IsItemVisible();
+		return ImGui::IsItemVisible();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemEdited()",
 	[]() -> bool {
-	    return ImGui::IsItemEdited();
+		return ImGui::IsItemEdited();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemActivated()",
 	[]() -> bool {
-	    return ImGui::IsItemActivated();
+		return ImGui::IsItemActivated();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemDeactivated()",
 	[]() -> bool {
-	    return ImGui::IsItemDeactivated();
+		return ImGui::IsItemDeactivated();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemDeactivatedAfterEdit()",
 	[]() -> bool {
-	    return ImGui::IsItemDeactivatedAfterEdit();
+		return ImGui::IsItemDeactivatedAfterEdit();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsItemToggledOpen()",
 	[]() -> bool {
-	    return ImGui::IsItemToggledOpen();
+		return ImGui::IsItemToggledOpen();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsAnyItemHovered()",
 	[]() -> bool {
-	    return ImGui::IsAnyItemHovered();
+		return ImGui::IsAnyItemHovered();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsAnyItemActive()",
 	[]() -> bool {
-	    return ImGui::IsAnyItemActive();
+		return ImGui::IsAnyItemActive();
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool IsAnyItemFocused()",
 	[]() -> bool {
-	    return ImGui::IsAnyItemFocused();
+		return ImGui::IsAnyItemFocused();
 	});
 	FAngelscriptBinds::BindGlobalFunction("FVector2f GetItemRectMin()",
 	[]() -> FVector2f {
-	    return ToUnreal(ImGui::GetItemRectMin());
+		return ToUnreal(ImGui::GetItemRectMin());
 	});
 	FAngelscriptBinds::BindGlobalFunction("FVector2f GetItemRectMax()",
 	[]() -> FVector2f {
-	    return ToUnreal(ImGui::GetItemRectMax());
+		return ToUnreal(ImGui::GetItemRectMax());
 	});
 	FAngelscriptBinds::BindGlobalFunction("FVector2f GetItemRectSize()",
 	[]() -> FVector2f {
-	    return ToUnreal(ImGui::GetItemRectSize());
+		return ToUnreal(ImGui::GetItemRectSize());
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetItemAllowOverlap()",
 	[]() -> void {
-	    ImGui::SetItemAllowOverlap();
+		ImGui::SetItemAllowOverlap();
 	});
 });
 
@@ -1929,13 +1928,13 @@ FAngelscriptBinds::FBind Bind_ImGui_Style(FAngelscriptBinds::EOrder::Late, []
 		ImGui::PopStyleColor(Count);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PushStyleVar(EImGuiStyleVar idx, float32 val)",
-[](ImGuiStyleVar Idx, float Val) {
+	[](ImGuiStyleVar Idx, float Val) {
 		ImGui::PushStyleVar(Idx, Val);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PushStyleVar(EImGuiStyleVar idx, const FVector2f& val)",
-		[](ImGuiStyleVar Idx, const FVector2f& Val) {
-			ImGui::PushStyleVar(Idx, ToImGui(Val));
-		});
+	[](ImGuiStyleVar Idx, const FVector2f& Val) {
+		ImGui::PushStyleVar(Idx, ToImGui(Val));
+	});
 	FAngelscriptBinds::BindGlobalFunction("void PopStyleVar(int32 Count = 1)",
 	[](const int32 Count) {
 		ImGui::PopStyleVar(Count);

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -838,6 +838,26 @@ FAngelscriptBinds::FBind Bind_ImGui_Layout(FAngelscriptBinds::EOrder::Late, []
 	{
 		ImGui::EndGroup();
 	});
+	FAngelscriptBinds::BindGlobalFunction("FVector2f GetCursorPos()",
+	[]() -> FVector2f
+	{
+		return ToUnreal(ImGui::GetCursorPos());
+	});
+	FAngelscriptBinds::BindGlobalFunction("float32 GetCursorPosX()",
+	[]() -> float
+	{
+		return ImGui::GetCursorPosX();
+	});
+	FAngelscriptBinds::BindGlobalFunction("float32 GetCursorPosY()",
+	[]() -> float
+	{
+		return ImGui::GetCursorPosY();
+	});
+	FAngelscriptBinds::BindGlobalFunction("void SetCursorPos(const FVector2f& Position)",
+	[](const FVector2f& Position) -> void
+	{
+		ImGui::SetCursorPos(ToImGui(Position));
+	});
 });
 
 FAngelscriptBinds::FBind Bind_ImGui_Text_Widgets(FAngelscriptBinds::EOrder::Late, []

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -888,6 +888,11 @@ FAngelscriptBinds::FBind Bind_ImGui_Main_Widgets(FAngelscriptBinds::EOrder::Late
 	{
 		return ImGui::Button(ToImGui(Label));
 	});
+	FAngelscriptBinds::BindGlobalFunction("bool Button(const FString& Label, const FVector2f& Size)",
+	[](const FString& Label, const FVector2f& Size) -> bool
+	{
+		return ImGui::Button(ToImGui(Label), ToImGui(Size));
+	});
 	FAngelscriptBinds::BindGlobalFunction("bool SmallButton(const FString& Label)",
 	[](const FString& Label) -> bool
 	{

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -698,6 +698,11 @@ FAngelscriptBinds::FBind Bind_ImGui_Window_Utilities(FAngelscriptBinds::EOrder::
     {
         return ImGui::GetWindowHeight();
     });
+	FAngelscriptBinds::BindGlobalFunction("float32 GetWindowContentRegionWidth()",
+	[]() -> float
+	{
+		return ImGui::GetWindowContentRegionWidth();
+	});
 });
 
 FAngelscriptBinds::FBind Bind_ImGui_Window_Manipulation(FAngelscriptBinds::EOrder::Late, []

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -1940,6 +1940,14 @@ FAngelscriptBinds::FBind Bind_ImGui_Style(FAngelscriptBinds::EOrder::Late, []
 	[](const int32 Count) {
 		ImGui::PopStyleVar(Count);
 	});
+	FAngelscriptBinds::BindGlobalFunction("void PushItemWidth(float32 Width)",
+	[](const float Width) {
+		ImGui::PushItemWidth(Width);
+	});
+	FAngelscriptBinds::BindGlobalFunction("void PopItemWidth()",
+	[]() {
+		ImGui::PopItemWidth();
+	});
 });
 
 FAngelscriptBinds::FBind Bind_ImGui_Widget_InputUtilitiesMouse(FAngelscriptBinds::EOrder::Late, []

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -818,12 +818,12 @@ FAngelscriptBinds::FBind Bind_ImGui_Layout(FAngelscriptBinds::EOrder::Late, []
 	{
 		ImGui::Dummy(ToImGui(Size));
 	});
-	FAngelscriptBinds::BindGlobalFunction("void Indent(float32 Indent)",
+	FAngelscriptBinds::BindGlobalFunction("void Indent(float32 Indent= 0.0f)",
 	[](const float Indent) -> void
 	{
 		ImGui::Indent(Indent);
 	});
-	FAngelscriptBinds::BindGlobalFunction("void Unindent(float32 Size)",
+	FAngelscriptBinds::BindGlobalFunction("void Unindent(float32 Size= 0.0f)",
 	[](const float Indent) -> void
 	{
 		ImGui::Unindent(Indent);

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -631,12 +631,12 @@ FAngelscriptBinds::FBind Bind_ImGui_Windows(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool Begin(const FString& Name, EImGuiWindowFlags Flags = EImGuiWindowFlags::None)",
 	[](const FString& Name, const ImGuiWindowFlags Flags) -> bool
 	{
-		return ImGui::Begin(ToImGui(Name), nullptr, Flags);
+		return ImGui::Begin(IMGUI_STR(Name), nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool Begin(const FString& Name, bool& bOpen, EImGuiWindowFlags Flags = EImGuiWindowFlags::None)",
 	[](const FString& Name, bool& bOpen, const ImGuiWindowFlags Flags) -> bool
 	{
-		return ImGui::Begin(ToImGui(Name), &bOpen, Flags);
+		return ImGui::Begin(IMGUI_STR(Name), &bOpen, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void End()",
 	[]() -> void
@@ -646,7 +646,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Windows(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginChild(const FString& Name, const FVector2f& Size = FVector2f(0, 0), bool bBorder = false, EImGuiWindowFlags Flags = EImGuiWindowFlags::None)",
 	[](const FString& Name, const FVector2f& Position, const bool bBorder, const ImGuiWindowFlags Flags) -> bool
 	{
-		return ImGui::BeginChild(ToImGui(Name), ToImGui(Position), bBorder, Flags);
+		return ImGui::BeginChild(IMGUI_STR(Name), ToImGui(Position), bBorder, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndChild()",
 	[]() -> void
@@ -771,22 +771,22 @@ FAngelscriptBinds::FBind Bind_ImGui_Window_Manipulation(FAngelscriptBinds::EOrde
 	FAngelscriptBinds::BindGlobalFunction("void SetWindowPosition(const FString& Name, const FVector2f& Position, EImGuiCond Condition = EImGuiCond::None)",
 	[](const FString& Name, const FVector2f& Position, const ImGuiCond Condition) -> void
 	{
-		ImGui::SetWindowPos(ToImGui(Name), ToImGui(Position), Condition);
+		ImGui::SetWindowPos(IMGUI_STR(Name), ToImGui(Position), Condition);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetWindowSize(const FString& Name, const FVector2f& Size, EImGuiCond Condition = EImGuiCond::None)",
 	[](const FString& Name, const FVector2f& Size, const ImGuiCond Condition) -> void
 	{
-		ImGui::SetWindowSize(ToImGui(Name), ToImGui(Size), Condition);
+		ImGui::SetWindowSize(IMGUI_STR(Name), ToImGui(Size), Condition);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetWindowCollapsed(const FString& Name, bool Collapsed, EImGuiCond Condition = EImGuiCond::None)",
 	[](const FString& Name, const bool Collapsed, const ImGuiCond Condition) -> void
 	{
-		ImGui::SetWindowCollapsed(ToImGui(Name), Collapsed, Condition);
+		ImGui::SetWindowCollapsed(IMGUI_STR(Name), Collapsed, Condition);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetWindowFocus(const FString& Name)",
-	[](const char* Name) -> void
+	[](const FString& Name) -> void
 	{
-		ImGui::SetWindowFocus(ToImGui(Name));
+		ImGui::SetWindowFocus(IMGUI_STR(Name));
 	});
 });
 
@@ -866,37 +866,37 @@ FAngelscriptBinds::FBind Bind_ImGui_Text_Widgets(FAngelscriptBinds::EOrder::Late
 	FAngelscriptBinds::BindGlobalFunction("void TextUnformatted(const FString& Text)",
 	[](const FString& Text) -> void
 	{
-		ImGui::TextUnformatted(ToImGui(Text));
+		ImGui::TextUnformatted(IMGUI_STR(Text));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void Text(const FString& Text)",
 	[](const FString& Text) -> void
 	{
-		ImGui::Text(ToImGui(Text));
+		ImGui::Text(IMGUI_STR(Text));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void TextColored(const FColor& Color, const FString& Text)",
 	[](const FColor& Color, const FString& Text) -> void
 	{
-		ImGui::TextColored(ToImGui(Color), ToImGui(Text));
+		ImGui::TextColored(ToImGui(Color), IMGUI_STR(Text));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void TextDisabled(const FString& Text)",
 	[](const FString& Text) -> void
 	{
-		ImGui::TextDisabled(ToImGui(Text));
+		ImGui::TextDisabled(IMGUI_STR(Text));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void TextWrapped(const FString& Text)",
 	[](const FString& Text) -> void
 	{
-		ImGui::TextWrapped(ToImGui(Text));
+		ImGui::TextWrapped(IMGUI_STR(Text));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void LabelText(const FString& Label, const FString& Text)",
 	[](const FString& Label, const FString& Text) -> void
 	{
-		ImGui::LabelText(ToImGui(Label), ToImGui(Text));
+		ImGui::LabelText(IMGUI_STR(Label), IMGUI_STR(Text));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void BulletText(const FString& Text)",
 	[](const FString& Text) -> void
 	{
-		ImGui::BulletText(ToImGui(Text));
+		ImGui::BulletText(IMGUI_STR(Text));
 	});
 });
 
@@ -906,37 +906,37 @@ FAngelscriptBinds::FBind Bind_ImGui_Main_Widgets(FAngelscriptBinds::EOrder::Late
 	FAngelscriptBinds::BindGlobalFunction("bool Button(const FString& Label)",
 	[](const FString& Label) -> bool
 	{
-		return ImGui::Button(ToImGui(Label));
+		return ImGui::Button(IMGUI_STR(Label));
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool Button(const FString& Label, const FVector2f& Size)",
 	[](const FString& Label, const FVector2f& Size) -> bool
 	{
-		return ImGui::Button(ToImGui(Label), ToImGui(Size));
+		return ImGui::Button(IMGUI_STR(Label), ToImGui(Size));
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SmallButton(const FString& Label)",
 	[](const FString& Label) -> bool
 	{
-		return ImGui::SmallButton(ToImGui(Label));
+		return ImGui::SmallButton(IMGUI_STR(Label));
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool Checkbox(const FString& Label, bool& bValue)",
 	[](const FString& Label, bool& bValue) -> bool
 	{
-		return ImGui::Checkbox(ToImGui(Label), &bValue);
+		return ImGui::Checkbox(IMGUI_STR(Label), &bValue);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool RadioButton(const FString& Label, bool bActive)",
 	[](const FString& Label, const bool bActive) -> bool
 	{
-		return ImGui::RadioButton(ToImGui(Label), bActive);
+		return ImGui::RadioButton(IMGUI_STR(Label), bActive);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool RadioButton(const FString& Label, int32& Value, int32 ButtonValue)",
 	[](const FString& Label, int32& Value, const int32 ButtonValue) -> bool
 	{
-		return ImGui::RadioButton(ToImGui(Label), &Value, ButtonValue);
+		return ImGui::RadioButton(IMGUI_STR(Label), &Value, ButtonValue);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool ProgressBar(float32 Fraction, const FVector2f& Size = FVector2f(-1, 0), const FString& Overlay = \"\")",
 	[](const float Fraction, const FVector2f& Size, const FString& Overlay) -> void
 	{
-		ImGui::ProgressBar(Fraction, ToImGui(Size), ToImGui(Overlay));
+		ImGui::ProgressBar(Fraction, ToImGui(Size), IMGUI_STR(Overlay));
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool Bullet()",
 	[]() -> void
@@ -951,7 +951,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Combo(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginCombo(const FString& Label, const FString& PreviewValue, EImGuiComboFlags Flags = EImGuiComboFlags::None)",
 	[](const FString& Label, const FString& PreviewValue, const ImGuiComboFlags Flags) -> bool
 	{
-		return ImGui::BeginCombo(ToImGui(Label), ToImGui(PreviewValue), Flags);
+		return ImGui::BeginCombo(IMGUI_STR(Label), IMGUI_STR(PreviewValue), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndCombo()",
 	[]() -> void
@@ -962,7 +962,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Combo(FAngelscriptBinds::EOrder::Late, []
 	[](const FString& Label, int32& CurrentItem, const TArray<FString>& Items, const int32 PopupMaxItems = -1) -> bool
 	{
 		FStringArrayToPtrHelper ItemsBuffer(Items);
-		return ImGui::Combo(ToImGui(Label), &CurrentItem, ItemsBuffer.GetPtr(), Items.Num(), PopupMaxItems);
+		return ImGui::Combo(IMGUI_STR(Label), &CurrentItem, ItemsBuffer.GetPtr(), Items.Num(), PopupMaxItems);
 	});
 });
 
@@ -972,7 +972,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Table(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginTable(const FString& Label, const int Column, EImGuiTableFlags Flags = EImGuiTableFlags::None)",
 	[](const FString& Label, const int Column, const ImGuiTableFlags Flags) -> bool
 	{
-		return ImGui::BeginTable(ToImGui(Label), Column, Flags);
+		return ImGui::BeginTable(IMGUI_STR(Label), Column, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndTable()",
 	[]() -> void
@@ -982,7 +982,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Table(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("void TableSetupColumn(const FString& Label, EImGuiTableFlags Flags = EImGuiTableFlags::None)",
 	[](const FString& Label, const ImGuiTableFlags Flags) -> void
 	{
-		ImGui::TableSetupColumn(ToImGui(Label), Flags);
+		ImGui::TableSetupColumn(IMGUI_STR(Label), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void TableNextColumn()",
 	[]() -> void
@@ -1007,67 +1007,67 @@ FAngelscriptBinds::FBind Bind_ImGui_Slider_Widgets(FAngelscriptBinds::EOrder::La
 	FAngelscriptBinds::BindGlobalFunction("bool SliderFloat(const FString& Label, float32& Value, const float32 Min, const float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, float& Value, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_Float, &Value, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_Float, &Value, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderFloat(const FString& Label, float64& Value, const float64 Min, const float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, double& Value, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_Double, &Value, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_Double, &Value, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, int64& Value, int64 Min, int64 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int64& Value, const int64 Min, const int64 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_S64, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_S64, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, uint64& Value, int64 Min, uint64 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint64& Value, const uint64 Min, const uint64 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_U64, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_U64, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, int32& Value, int32 Min, int32 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int32& Value, const int32 Min, const int32 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_S32, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_S32, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, uint32& Value, int64 Min, uint32 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint32& Value, const uint32 Min, const uint32 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_U32, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_U32, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, int16& Value, int64 Min, int16 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int16& Value, const int16 Min, const int16 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_S16, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_S16, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, uint16& Value, int64 Min, uint16 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint16& Value, const uint16 Min, const uint16 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_U16, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_U16, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, int8& Value, int64 Min, int8 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int8& Value, const int8 Min, const int8 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_S8, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_S8, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderInt(const FString& Label, uint8& Value, int64 Min, uint8 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint8& Value, const uint8 Min, const uint8 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalar(ToImGui(Label), ImGuiDataType_U8, &Value, &Min, &Max, nullptr, Flags);
+		return ImGui::SliderScalar(IMGUI_STR(Label), ImGuiDataType_U8, &Value, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderFloat2(const FString& Label, FVector2f& Value, float32 Min, float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector2f& Value, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalarN(ToImGui(Label), ImGuiDataType_Float, &Value, 2, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::SliderScalarN(IMGUI_STR(Label), ImGuiDataType_Float, &Value, 2, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderFloat2(const FString& Label, FVector2D& Value, float64 Min, float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector2D& Value, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalarN(ToImGui(Label), ImGuiDataType_Double, &Value, 2, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::SliderScalarN(IMGUI_STR(Label), ImGuiDataType_Double, &Value, 2, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool SliderFloat3(const FString& Label, FVector3f& Value, float32 Min, float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector3f& Value, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalarN(ToImGui(Label), ImGuiDataType_Float, &Value, 3, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::SliderScalarN(IMGUI_STR(Label), ImGuiDataType_Float, &Value, 3, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	// FAngelscriptBinds::BindGlobalFunction("bool SliderFloat3(const FString& Label, FVector3d& Value, float64 Min, float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	// [](const FString& Label, FVector3d& Value, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
@@ -1077,7 +1077,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Slider_Widgets(FAngelscriptBinds::EOrder::La
 	FAngelscriptBinds::BindGlobalFunction("bool SliderFloat3(const FString& Label, FVector& Value, float64 Min, float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector& Value, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::SliderScalarN(ToImGui(Label), ImGuiDataType_Double, &Value, 3, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::SliderScalarN(IMGUI_STR(Label), ImGuiDataType_Double, &Value, 3, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	// FAngelscriptBinds::BindGlobalFunction("bool SliderFloat4(const FString& Label, FVector4f& Value, float32 Min, float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	// [](const FString& Label, FVector4f& Value, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
@@ -1190,67 +1190,67 @@ FAngelscriptBinds::FBind Bind_ImGui_Drag_Widgets(FAngelscriptBinds::EOrder::Late
 	FAngelscriptBinds::BindGlobalFunction("bool DragFloat(const FString& Label, float32& Value, float32 Speed, float32 Min, float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, float& Value, const float Speed, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_Float, &Value, Speed, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_Float, &Value, Speed, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragFloat(const FString& Label, float64& Value, float32 Speed, float64 Min, float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, double& Value, const float Speed, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_Double, &Value, Speed, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_Double, &Value, Speed, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, int64& Value, float32 Speed, int64 Min, int64 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int64& Value, const float Speed, const int64 Min, const int64 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_S64, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_S64, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, uint64& Value, float32 Speed, uint64 Min, uint64 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint64& Value, const float Speed, const uint64 Min, const uint64 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_U64, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_U64, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, int32& Value, float32 Speed, int32 Min, int32 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int32& Value, const float Speed, const int32 Min, const int32 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_S32, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_S32, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, uint32& Value, float32 Speed, uint32 Min, uint32 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint32& Value, const float Speed, const uint32 Min, const uint32 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_U32, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_U32, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, int16& Value, float32 Speed, int16 Min, int16 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int16& Value, const float Speed, const int16 Min, const int16 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_S16, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_S16, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, uint16& Value, float32 Speed, uint16 Min, uint16 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint16& Value, const float Speed, const uint16 Min, const uint16 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_U16, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_U16, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, int8& Value, float32 Speed, int8 Min, int8 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, int8& Value, const float Speed, const int8 Min, const int8 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_S8, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_S8, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragInt(const FString& Label, uint8& Value, float32 Speed, uint8 Min, uint8 Max, EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, uint8& Value, const float Speed, const uint8 Min, const uint8 Max, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalar(ToImGui(Label), ImGuiDataType_U8, &Value, Speed, &Min, &Max, nullptr, Flags);
+		return ImGui::DragScalar(IMGUI_STR(Label), ImGuiDataType_U8, &Value, Speed, &Min, &Max, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragFloat2(const FString& Label, FVector2f& Value, float32 Speed, float32 Min, float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector2f& Value, const float Speed, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalarN(ToImGui(Label), ImGuiDataType_Float, &Value, 2, Speed, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::DragScalarN(IMGUI_STR(Label), ImGuiDataType_Float, &Value, 2, Speed, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragFloat2(const FString& Label, FVector2D& Value, float32 Speed, float64 Min, float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector2D& Value, const float Speed, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalarN(ToImGui(Label), ImGuiDataType_Double, &Value, 2, Speed, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::DragScalarN(IMGUI_STR(Label), ImGuiDataType_Double, &Value, 2, Speed, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool DragFloat3(const FString& Label, FVector3f& Value, float32 Speed, float32 Min, float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector3f& Value, const float Speed, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalarN(ToImGui(Label), ImGuiDataType_Float, &Value, 3, Speed, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::DragScalarN(IMGUI_STR(Label), ImGuiDataType_Float, &Value, 3, Speed, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	// FAngelscriptBinds::BindGlobalFunction("bool DragFloat3(const FString& Label, FVector3d& Value, float32 Speed, float64 Min, float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	// [](const FString& Label, FVector3d& Value, const float Speed, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
@@ -1260,7 +1260,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Drag_Widgets(FAngelscriptBinds::EOrder::Late
 	FAngelscriptBinds::BindGlobalFunction("bool DragFloat3(const FString& Label, FVector& Value, float32 Speed, float64 Min, float64 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	[](const FString& Label, FVector& Value, const float Speed, const double Min, const double Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
 	{
-		return ImGui::DragScalarN(ToImGui(Label), ImGuiDataType_Double, &Value, 3, Speed, &Min, &Max, ToImGui(Format), Flags);
+		return ImGui::DragScalarN(IMGUI_STR(Label), ImGuiDataType_Double, &Value, 3, Speed, &Min, &Max, IMGUI_STR(Format), Flags);
 	});
 	// FAngelscriptBinds::BindGlobalFunction("bool DragFloat4(const FString& Label, FVector4f& Value, float32 Speed, float32 Min, float32 Max, const FString& Format = \"%.3f\", EImGuiSliderFlags Flags = EImGuiSliderFlags::None)",
 	// [](const FString& Label, FVector4f& Value, const float Speed, const float Min, const float Max, const FString& Format, const ImGuiSliderFlags Flags) -> bool
@@ -1391,7 +1391,7 @@ FAngelscriptBinds::FBind Bind_ImGui_InputText(FAngelscriptBinds::EOrder::Late, [
 			{
 				FCStringAnsi::Strncpy(Array.GetData(), TCHAR_TO_UTF8(*Buffer), Array.Num());
 			}
-			return ImGui::InputText(ToImGui(Label), Array.GetData(), Array.Num(), Flags, [](ImGuiInputTextCallbackData* Data)
+			return ImGui::InputText(IMGUI_STR(Label), Array.GetData(), Array.Num(), Flags, [](ImGuiInputTextCallbackData* Data)
 			{
 				*static_cast<FString*>(Data->UserData) = FString(UTF8_TO_TCHAR(Data->Buf));
 				return 0;
@@ -1404,73 +1404,73 @@ FAngelscriptBinds::FBind Bind_ImGui_Input_Widgets(FAngelscriptBinds::EOrder::Lat
 	FAngelscriptBinds::BindGlobalFunction("bool InputFloat(const FString& Label, float32& Value, float32 Step = 0.1, float32 StepFast = 10, const FString& Format = \"%.3f\", EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, float& Value, const float Step, const float StepFast, const FString& Format, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_Float, &Value, &Step, &StepFast, ToImGui(Format), Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_Float, &Value, &Step, &StepFast, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputFloat(const FString& Label, float64& Value, float64 Step = 0.1, float64 StepFast = 10, const FString& Format = \"%.3f\", EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, double& Value, const double Step, const double StepFast, const FString& Format, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_Double, &Value, &Step, &StepFast, ToImGui(Format), Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_Double, &Value, &Step, &StepFast, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, int64& Value, int64 Step = 1, int64 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, int64& Value, const int64 Step, const int64 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_S64, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_S64, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, uint64& Value, int64 Step = 1, uint64 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, uint64& Value, const uint64 Step, const uint64 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_U64, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_U64, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, int32& Value, int32 Step = 1, int32 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, int32& Value, const int32 Step, const int32 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_S32, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_S32, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, uint32& Value, int64 Step = 1, uint32 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, uint32& Value, const uint32 Step, const uint32 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_U32, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_U32, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, int16& Value, int64 Step = 1, int16 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, int16& Value, const int16 Step, const int16 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_S16, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_S16, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, uint16& Value, int64 Step = 1, uint16 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, uint16& Value, const uint16 Step, const uint16 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_U16, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_U16, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, int8& Value, int64 Step = 1, int8 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, int8& Value, const int8 Step, const int8 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_S8, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_S8, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputInt(const FString& Label, uint8& Value, int64 Step = 1, uint8 StepFast = 100, EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, uint8& Value, const uint8 Step, const uint8 StepFast, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalar(ToImGui(Label), ImGuiDataType_U8, &Value, &Step, &StepFast, nullptr, Flags);
+		return ImGui::InputScalar(IMGUI_STR(Label), ImGuiDataType_U8, &Value, &Step, &StepFast, nullptr, Flags);
 	});
 
 	FAngelscriptBinds::BindGlobalFunction("bool InputFloat2(const FString& Label, FVector2f& Value, float32 Step = 0.1, float32 StepFast = 10, const FString& Format = \"%.3f\", EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, FVector2f& Value, const float Step, const float StepFast, const FString& Format, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalarN(ToImGui(Label), ImGuiDataType_Float, &Value, 2, &Step, &StepFast, ToImGui(Format), Flags);
+		return ImGui::InputScalarN(IMGUI_STR(Label), ImGuiDataType_Float, &Value, 2, &Step, &StepFast, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputFloat2(const FString& Label, FVector2D& Value, float64 Step = 0.1, float64 StepFast = 10, const FString& Format = \"%.3f\", EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, FVector2D& Value, const double Step, const double StepFast, const FString& Format, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalarN(ToImGui(Label), ImGuiDataType_Double, &Value, 2, &Step, &StepFast, ToImGui(Format), Flags);
+		return ImGui::InputScalarN(IMGUI_STR(Label), ImGuiDataType_Double, &Value, 2, &Step, &StepFast, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputFloat3(const FString& Label, FVector3f& Value, float32 Step = 0.1, float32 StepFast = 10, const FString& Format = \"%.3f\", EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, FVector3f& Value, const float Step, const float StepFast, const FString& Format, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalarN(ToImGui(Label), ImGuiDataType_Float, &Value, 3, &Step, &StepFast, ToImGui(Format), Flags);
+		return ImGui::InputScalarN(IMGUI_STR(Label), ImGuiDataType_Float, &Value, 3, &Step, &StepFast, IMGUI_STR(Format), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool InputFloat3(const FString& Label, FVector& Value, float64 Step = 0.1, float64 StepFast = 10, const FString& Format = \"%.3f\", EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	[](const FString& Label, FVector& Value, const double Step, const double StepFast, const FString& Format, const ImGuiInputTextFlags Flags) -> bool
 	{
-		return ImGui::InputScalarN(ToImGui(Label), ImGuiDataType_Double, &Value, 3, &Step, &StepFast, ToImGui(Format), Flags);
+		return ImGui::InputScalarN(IMGUI_STR(Label), ImGuiDataType_Double, &Value, 3, &Step, &StepFast, IMGUI_STR(Format), Flags);
 	});
 	// FAngelscriptBinds::BindGlobalFunction("bool InputFloat4(const FString& Label, FVector4f& Value, float32 Step = 0.1, float32 StepFast = 10, const FString& Format = \"%.3f\", EImGuiInputTextFlags Flags = EImGuiInputTextFlags::None)",
 	// [](const FString& Label, FVector4f& Value, const float Step, const float StepFast, const FString& Format, const ImGuiInputTextFlags Flags) -> bool
@@ -1591,7 +1591,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Selectables(FAngelscriptBinds::EOrder::Late,
 	FAngelscriptBinds::BindGlobalFunction("bool Selectable(const FString& Label, bool& bSelected, const FVector2f& Size = FVector2f(0, 0), EImGuiSelectableFlags Flags = EImGuiSelectableFlags::None)",
 	[](const FString& Label, bool& bSelected, const FVector2f& Size, const ImGuiSelectableFlags Flags) -> bool
 	{
-		return ImGui::Selectable(ToImGui(Label), &bSelected, Flags, ToImGui(Size));
+		return ImGui::Selectable(IMGUI_STR(Label), &bSelected, Flags, ToImGui(Size));
 	});
 });
 
@@ -1601,7 +1601,7 @@ FAngelscriptBinds::FBind Bind_ImGui_ListBox(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginListBox(const FString& Label, const FVector2f& Size = FVector2f(0, 0))",
 	[](const FString& Label, const FVector2f& Size) -> bool
 	{
-		return ImGui::BeginListBox(ToImGui(Label), ToImGui(Size));
+		return ImGui::BeginListBox(IMGUI_STR(Label), ToImGui(Size));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndListBox()",
 	[]() -> void
@@ -1612,7 +1612,7 @@ FAngelscriptBinds::FBind Bind_ImGui_ListBox(FAngelscriptBinds::EOrder::Late, []
 	[](const FString& Label, int32& CurrentItem, const TArray<FString>& Items, const int32 HeightInItems = -1) -> bool
 	{
 		FStringArrayToPtrHelper ItemsBuffer(Items);
-		return ImGui::ListBox(ToImGui(Label), &CurrentItem, ItemsBuffer.GetPtr(), Items.Num(), HeightInItems);
+		return ImGui::ListBox(IMGUI_STR(Label), &CurrentItem, ItemsBuffer.GetPtr(), Items.Num(), HeightInItems);
 	});
 });
 
@@ -1642,7 +1642,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Menu_Widgets(FAngelscriptBinds::EOrder::Late
 	FAngelscriptBinds::BindGlobalFunction("bool BeginMenu(const FString& Label, const bool bEnabled = true)",
 	[](const FString& Label, const bool bEnabled) -> bool
 	{
-		return ImGui::BeginMenu(ToImGui(Label), bEnabled);
+		return ImGui::BeginMenu(IMGUI_STR(Label), bEnabled);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndMenu()",
 	[]() -> void
@@ -1652,8 +1652,8 @@ FAngelscriptBinds::FBind Bind_ImGui_Menu_Widgets(FAngelscriptBinds::EOrder::Late
 	FAngelscriptBinds::BindGlobalFunction("bool MenuItem(const FString& Label, const FString& Shortcut = \"\", bool bSelected = false, bool bEnabled = true)",
 	[](const FString& Label, const FString& Shortcut, const bool bSelected, const bool bEnabled) -> bool
 	{
-		const char* ImGuiShortcut = Shortcut.IsEmpty() ? nullptr : ToImGui(Shortcut);
-		return ImGui::MenuItem(ToImGui(Label), ImGuiShortcut, bSelected, bEnabled);
+		const char* ImGuiShortcut = Shortcut.IsEmpty() ? nullptr : IMGUI_STR(Shortcut);
+		return ImGui::MenuItem(IMGUI_STR(Label), ImGuiShortcut, bSelected, bEnabled);
 	});
 });
 
@@ -1673,7 +1673,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Tooltips(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool SetTooltip(const FString& Text)",
 	[](const FString& Identifier) -> void
 	{
-		ImGui::SetTooltip(ToImGui(Identifier));
+		ImGui::SetTooltip(IMGUI_STR(Identifier));
 	});
 });
 
@@ -1683,12 +1683,12 @@ FAngelscriptBinds::FBind Bind_ImGui_TreeNode(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool TreeNode(const FString& Label)",
 	[](const FString& Label) -> bool
 	{
-		return ImGui::TreeNode(ToImGui(Label));
+		return ImGui::TreeNode(IMGUI_STR(Label));
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool TreeNodeEx(const FString& Label, EImGuiTreeNodeFlags Flags = EImGuiTreeNodeFlags::None)",
 	[](const FString& Label, const ImGuiTreeNodeFlags Flags) -> bool
 	{
-		return ImGui::TreeNodeEx(ToImGui(Label), Flags);
+		return ImGui::TreeNodeEx(IMGUI_STR(Label), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void TreePop()",
 	[]() -> void
@@ -1703,7 +1703,7 @@ FAngelscriptBinds::FBind Bind_ImGui_TreeNode(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool CollapsingHeader(const FString& Label, EImGuiTreeNodeFlags Flags = EImGuiTreeNodeFlags::None)",
 	[](const FString& Label, const ImGuiTreeNodeFlags Flags) -> bool
 	{
-		return ImGui::CollapsingHeader(ToImGui(Label), Flags);
+		return ImGui::CollapsingHeader(IMGUI_STR(Label), Flags);
 	});
 });
 
@@ -1713,17 +1713,17 @@ FAngelscriptBinds::FBind Bind_ImGui_Popups(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginPopup(const FString& Identifier, EImGuiWindowFlags Flags = EImGuiWindowFlags::None)",
 	[](const FString& Identifier, const ImGuiWindowFlags Flags) -> bool
 	{
-		return ImGui::BeginPopup(ToImGui(Identifier), Flags);
+		return ImGui::BeginPopup(IMGUI_STR(Identifier), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool BeginPopupModal(const FString& Name, EImGuiWindowFlags Flags = EImGuiWindowFlags::None)",
 	[](const FString& Name, const ImGuiWindowFlags Flags) -> bool
 	{
-		return ImGui::BeginPopupModal(ToImGui(Name), nullptr, Flags);
+		return ImGui::BeginPopupModal(IMGUI_STR(Name), nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool BeginPopupModal(const FString& Name, bool& bOpen, EImGuiWindowFlags Flags = EImGuiWindowFlags::None)",
 	[](const FString& Name, bool& bOpen, const ImGuiWindowFlags Flags) -> bool
 	{
-		return ImGui::BeginPopupModal(ToImGui(Name), &bOpen, Flags);
+		return ImGui::BeginPopupModal(IMGUI_STR(Name), &bOpen, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndPopup()",
 	[]() -> void
@@ -1733,12 +1733,12 @@ FAngelscriptBinds::FBind Bind_ImGui_Popups(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool OpenPopup(const FString& Identifier, EImGuiPopupFlags Flags = EImGuiPopupFlags::None)",
 	[](const FString& Identifier, const ImGuiPopupFlags Flags) -> void
 	{
-		ImGui::OpenPopup(ToImGui(Identifier), Flags);
+		ImGui::OpenPopup(IMGUI_STR(Identifier), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool OpenPopupOnItemClick(const FString& Identifier, EImGuiPopupFlags Flags = EImGuiPopupFlags::MouseButtonLeft)",
 	[](const FString& Identifier, const ImGuiPopupFlags Flags) -> void
 	{
-		ImGui::OpenPopupOnItemClick(ToImGui(Identifier), Flags);
+		ImGui::OpenPopupOnItemClick(IMGUI_STR(Identifier), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void CloseCurrentPopup()",
 	[]() -> void
@@ -1748,22 +1748,22 @@ FAngelscriptBinds::FBind Bind_ImGui_Popups(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginPopupContextItem(const FString& Identifier, EImGuiPopupFlags Flags = EImGuiPopupFlags::MouseButtonLeft)",
 	[](const FString& Identifier, const ImGuiPopupFlags Flags) -> void
 	{
-		ImGui::BeginPopupContextItem(ToImGui(Identifier), Flags);
+		ImGui::BeginPopupContextItem(IMGUI_STR(Identifier), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool BeginPopupContextWindow(const FString& Identifier, EImGuiPopupFlags Flags = EImGuiPopupFlags::MouseButtonLeft)",
 	[](const FString& Identifier, const ImGuiPopupFlags Flags) -> void
 	{
-		ImGui::BeginPopupContextWindow(ToImGui(Identifier), Flags);
+		ImGui::BeginPopupContextWindow(IMGUI_STR(Identifier), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool BeginPopupContextVoid(const FString& Identifier, EImGuiPopupFlags Flags = EImGuiPopupFlags::MouseButtonLeft)",
 	[](const FString& Identifier, const ImGuiPopupFlags Flags) -> void
 	{
-		ImGui::BeginPopupContextVoid(ToImGui(Identifier), Flags);
+		ImGui::BeginPopupContextVoid(IMGUI_STR(Identifier), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool CloseCurrentPopup(const FString& Identifier, EImGuiPopupFlags Flags = EImGuiPopupFlags::None)",
 	[](const FString& Identifier, ImGuiPopupFlags Flags) -> bool
 	{
-		return ImGui::IsPopupOpen(ToImGui(Identifier), Flags);
+		return ImGui::IsPopupOpen(IMGUI_STR(Identifier), Flags);
 	});
 });
 
@@ -1773,7 +1773,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Tabs(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginTabBar(const FString& Identifier, EImGuiTabBarFlags Flags = EImGuiTabBarFlags::None)",
 	[](const FString& Identifier, const ImGuiTabBarFlags Flags) -> bool
 	{
-		return ImGui::BeginTabBar(ToImGui(Identifier), Flags);
+		return ImGui::BeginTabBar(IMGUI_STR(Identifier), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndTabBar()",
 	[]() -> void
@@ -1783,12 +1783,12 @@ FAngelscriptBinds::FBind Bind_ImGui_Tabs(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginTabItem(const FString& Label, EImGuiTabItemFlags Flags = EImGuiTabItemFlags::None)",
 	[](const FString& Label, const ImGuiTabItemFlags Flags) -> bool
 	{
-		return ImGui::BeginTabItem(ToImGui(Label), nullptr, Flags);
+		return ImGui::BeginTabItem(IMGUI_STR(Label), nullptr, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool BeginTabItem(const FString& Label, bool& bOpen, EImGuiTabItemFlags Flags = EImGuiTabItemFlags::None)",
 	[](const FString& Label, bool& bOpen, const ImGuiTabItemFlags Flags) -> bool
 	{
-		return ImGui::BeginTabItem(ToImGui(Label), &bOpen, Flags);
+		return ImGui::BeginTabItem(IMGUI_STR(Label), &bOpen, Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndTabItem()",
 	[]() -> void
@@ -1798,12 +1798,12 @@ FAngelscriptBinds::FBind Bind_ImGui_Tabs(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool TabItemButton(const FString& Label, EImGuiTabItemFlags Flags = EImGuiTabItemFlags::None)",
 	[](const FString& Label, const ImGuiTabItemFlags Flags) -> bool
 	{
-		return ImGui::TabItemButton(ToImGui(Label), Flags);
+		return ImGui::TabItemButton(IMGUI_STR(Label), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetTabItemClosed(const FString& Label)",
 	[](const FString& Label) -> void
 	{
-		ImGui::SetTabItemClosed(ToImGui(Label));
+		ImGui::SetTabItemClosed(IMGUI_STR(Label));
 	});
 });
 

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImGui.cpp
@@ -1676,6 +1676,16 @@ FAngelscriptBinds::FBind Bind_ImGui_TreeNode(FAngelscriptBinds::EOrder::Late, []
 	{
 		ImGui::TreePop();
 	});
+	FAngelscriptBinds::BindGlobalFunction("void SetNextTreeNodeOpen(bool bOpen, EImGuiCond Cond = EImGuiCond::None)",
+	[](const bool bOpen, const ImGuiCond Cond) -> void
+	{
+		ImGui::SetNextItemOpen(bOpen, Cond);
+	});
+	FAngelscriptBinds::BindGlobalFunction("bool CollapsingHeader(const FString& Label, EImGuiTreeNodeFlags Flags = EImGuiTreeNodeFlags::None)",
+	[](const FString& Label, const ImGuiTreeNodeFlags Flags) -> bool
+	{
+		return ImGui::CollapsingHeader(ToImGui(Label), Flags);
+	});
 });
 
 FAngelscriptBinds::FBind Bind_ImGui_Popups(FAngelscriptBinds::EOrder::Late, []

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImPlot.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImPlot.cpp
@@ -29,11 +29,15 @@ FAngelscriptBinds::FBind Bind_ImPlotFlags(FAngelscriptBinds::EOrder::Early, []
     IMGUI_ENUM_VALUE(ImPlotFlags, NoInputs,);
     IMGUI_ENUM_VALUE(ImPlotFlags, NoMenus,);
     IMGUI_ENUM_VALUE(ImPlotFlags, NoBoxSelect,);
+#if !IMPLOT_LATEST
     IMGUI_ENUM_VALUE(ImPlotFlags, NoChild,);
+#endif
     IMGUI_ENUM_VALUE(ImPlotFlags, NoFrame,);
     IMGUI_ENUM_VALUE(ImPlotFlags, Equal,);
     IMGUI_ENUM_VALUE(ImPlotFlags, Crosshairs,);
+#if !IMPLOT_LATEST
     IMGUI_ENUM_VALUE(ImPlotFlags, AntiAliased,);
+#endif
     IMGUI_ENUM_VALUE(ImPlotFlags, CanvasOnly,);
 });
 
@@ -49,8 +53,10 @@ FAngelscriptBinds::FBind Bind_ImPlotAxisFlags(FAngelscriptBinds::EOrder::Early, 
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, NoMenus,);
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, Opposite,);
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, Foreground,);
+#if !IMPLOT_LATEST
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, LogScale,);
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, Time,);
+#endif
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, Invert,);
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, AutoFit,);
     IMGUI_ENUM_VALUE(ImPlotAxisFlags, RangeFit,);
@@ -456,7 +462,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotBarsH(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2f));
+			ImPlot::PlotBars(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, ImPlotBarsFlags_Horizontal, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotBarsH(const FString& Label, const TArray<FVector2D> Values, float64 BarHeight = 0.67)",
@@ -464,7 +470,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotBarsH(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2D));
+			ImPlot::PlotBars(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, ImPlotBarsFlags_Horizontal, sizeof(FVector2D));
 		}
 	});
 	// void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_width=0.67, double x0=0, ImPlotBarGroupsFlags flags=ImPlotBarGroupsFlags_None);
@@ -494,7 +500,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotVLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotInfLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotVLines(const FString& Label, const TArray<float64> Values)",
@@ -502,7 +508,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotVLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(double));
+			ImPlot::PlotInfLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(double));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotHLines(const FString& Label, const TArray<float32> Values)",
@@ -510,7 +516,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotHLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotInfLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), ImPlotInfLinesFlags_Horizontal, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotHLines(const FString& Label, const TArray<float64> Values)",
@@ -518,7 +524,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotHLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(double));
+			ImPlot::PlotInfLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), ImPlotInfLinesFlags_Horizontal, sizeof(double));
 		}
 	});
 	// void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, bool normalize=false, const char* label_fmt="%.1f", double angle0=90);
@@ -545,7 +551,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	FAngelscriptBinds::BindGlobalFunction("void PlotText(const FString& Text, float64 X, float64 Y, bool Vertical = false, const FVector2f& Offset = FVector2f(0, 0))",
 	[](const FString& Text, const double X, const double Y, const bool Vertical = false, const FVector2f& Offset = FVector2f(0, 0))
 	{
-		ImPlot::PlotText(IMGUI_STR(Text), X, Y, Vertical, ToImGui(Offset));
+		ImPlot::PlotText(IMGUI_STR(Text), X, Y, ToImGui(Offset), Vertical ? ImPlotTextFlags_Vertical : ImPlotTextFlags_None);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotDummy(const FString& Label)",
 	[](const FString& Label)

--- a/Source/AngelscriptImGui/Private/Binds/Bind_ImPlot.cpp
+++ b/Source/AngelscriptImGui/Private/Binds/Bind_ImPlot.cpp
@@ -239,7 +239,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Plot(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginPlot(const FString& Title, const FVector2f& Size = FVector2f(-1, 0), EImPlotFlags Flags = EImPlotFlags::None)",
 	[](const FString& Title, const FVector2f& Size, const ImPlotFlags Flags) -> bool
 	{
-		return ImPlot::BeginPlot(ToImGui(Title), ToImGui(Size), Flags);
+		return ImPlot::BeginPlot(IMGUI_STR(Title), ToImGui(Size), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndPlot()",
 	[]() -> void
@@ -254,12 +254,12 @@ FAngelscriptBinds::FBind Bind_ImGui_SubPlot(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("bool BeginSubplots(const FString& Title, int32 Rows, int32 Columns, const FVector2f& Size, EImPlotSubplotFlags Flags = EImPlotSubplotFlags::None)",
 	[](const FString& Title, const int32 Rows, const int32 Columns, const FVector2f& Size, const ImPlotSubplotFlags Flags) -> bool
 	{
-		return ImPlot::BeginSubplots(ToImGui(Title), Rows, Columns, ToImGui(Size), Flags);
+		return ImPlot::BeginSubplots(IMGUI_STR(Title), Rows, Columns, ToImGui(Size), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("bool BeginSubplots(const FString& Title, TArray<float32>& RowRatios, TArray<float32>& ColumnRatios, const FVector2f& Size, EImPlotSubplotFlags Flags = EImPlotSubplotFlags::None)",
 	[](const FString& Title, TArray<float>& RowRatios, TArray<float>& ColumnRatios, const FVector2f& Size, const ImPlotSubplotFlags Flags) -> bool
 	{
-		return ImPlot::BeginSubplots(ToImGui(Title), RowRatios.Num(), ColumnRatios.Num(), ToImGui(Size), Flags, RowRatios.GetData(), ColumnRatios.GetData());
+		return ImPlot::BeginSubplots(IMGUI_STR(Title), RowRatios.Num(), ColumnRatios.Num(), ToImGui(Size), Flags, RowRatios.GetData(), ColumnRatios.GetData());
 	});
 	FAngelscriptBinds::BindGlobalFunction("void EndSubplots()",
 	[]() -> void
@@ -274,7 +274,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Setup(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("void SetupAxis(EImAxis Axis, const FString& Label = FString(), EImPlotAxisFlags Flags = EImPlotAxisFlags::None)",
 	[](const ImAxis Axis, const FString& Label, const ImPlotAxisFlags Flags)
 	{
-		ImPlot::SetupAxis(Axis, Label.IsEmpty() ? nullptr : ToImGui(Label), Flags);
+		ImPlot::SetupAxis(Axis, Label.IsEmpty() ? nullptr : IMGUI_STR(Label), Flags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetupAxisLimits(EImAxis Axis, float64 VMin, float64 VMax, EImPlotCond Condition = EImPlotCond::Once)",
 	[](const ImAxis Axis, const double VMin, const double VMax, const ImPlotCond Condition)
@@ -289,7 +289,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Setup(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("void SetupAxisFormat(EImAxis Axis, const FString& Format)",
 	[](const ImAxis Axis, const FString& Format)
 	{
-		ImPlot::SetupAxisFormat(Axis, ToImGui(Format));
+		ImPlot::SetupAxisFormat(Axis, IMGUI_STR(Format));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetupAxisTicks(EImAxis Axis, const TArray<float64>& Values, bool KeepDefault = false)",
 	[](const ImAxis Axis, const TArray<double>& Values, const bool KeepDefault)
@@ -319,7 +319,7 @@ FAngelscriptBinds::FBind Bind_ImGui_Setup(FAngelscriptBinds::EOrder::Late, []
 	FAngelscriptBinds::BindGlobalFunction("void SetupAxes(const FString& XLabel, const FString& YLabel, EImPlotAxisFlags XFlags = EImPlotAxisFlags::None, EImPlotAxisFlags YFlags = EImPlotAxisFlags::None)",
 	[](const FString& XLabel, const FString& YLabel, const ImPlotAxisFlags XFlags, const ImPlotAxisFlags YFlags)
 	{
-		ImPlot::SetupAxes(ToImGui(XLabel), ToImGui(YLabel), XFlags, YFlags);
+		ImPlot::SetupAxes(IMGUI_STR(XLabel), IMGUI_STR(YLabel), XFlags, YFlags);
 	});
 	FAngelscriptBinds::BindGlobalFunction("void SetupAxesLimits(float64 XMin, float64 XMax, float64 YMin, float64 YMax, EImPlotCond Condition = EImPlotCond::Once)",
 	[](const double XMin, const double XMax, const double YMin, const double YMax, const ImPlotCond Condition)
@@ -376,7 +376,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotLine(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
+			ImPlot::PlotLine(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotLine(const FString& Label, const TArray<FVector2D> Values)",
@@ -384,7 +384,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotLine(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotLine(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotScatter(const FString& Label, const TArray<FVector2f> Values)",
@@ -392,7 +392,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotScatter(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
+			ImPlot::PlotScatter(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotScatter(const FString& Label, const TArray<FVector2D> Values)",
@@ -400,7 +400,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotScatter(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotScatter(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotStairs(const FString& Label, const TArray<FVector2f> Values)",
@@ -408,7 +408,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotStairs(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
+			ImPlot::PlotStairs(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotStairs(const FString& Label, const TArray<FVector2D> Values)",
@@ -416,7 +416,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotStairs(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotStairs(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotShaded(const FString& Label, const TArray<FVector2f> Values, float64 YReference = 0)",
@@ -424,7 +424,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotShaded(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), YReference, 0, sizeof(FVector2f));
+			ImPlot::PlotShaded(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), YReference, 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotShaded(const FString& Label, const TArray<FVector2D> Values, float64 YReference = 0)",
@@ -432,7 +432,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotShaded(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), YReference, 0, sizeof(FVector2D));
+			ImPlot::PlotShaded(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), YReference, 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotBars(const FString& Label, const TArray<FVector2f> Values, float64 BarWidth = 0.67)",
@@ -440,7 +440,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotBars(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarWidth, 0, sizeof(FVector2f));
+			ImPlot::PlotBars(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarWidth, 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotBars(const FString& Label, const TArray<FVector2D> Values, float64 BarWidth = 0.67)",
@@ -448,7 +448,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotBars(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarWidth, 0, sizeof(FVector2D));
+			ImPlot::PlotBars(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarWidth, 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotBarsH(const FString& Label, const TArray<FVector2f> Values, float64 BarHeight = 0.67)",
@@ -456,7 +456,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotBarsH(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2f));
+			ImPlot::PlotBarsH(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotBarsH(const FString& Label, const TArray<FVector2D> Values, float64 BarHeight = 0.67)",
@@ -464,7 +464,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotBarsH(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2D));
+			ImPlot::PlotBarsH(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2D));
 		}
 	});
 	// void PlotBarGroups(const char* const label_ids[], const T* values, int item_count, int group_count, double group_width=0.67, double x0=0, ImPlotBarGroupsFlags flags=ImPlotBarGroupsFlags_None);
@@ -478,7 +478,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotStems(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2f));
+			ImPlot::PlotStems(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotStems(const FString& Label, const TArray<FVector2D> Values, float64 BarHeight = 0.67)",
@@ -486,7 +486,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotStems(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2D));
+			ImPlot::PlotStems(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), BarHeight, 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotVLines(const FString& Label, const TArray<float32> Values)",
@@ -494,7 +494,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotVLines(ToImGui(Label), Values.GetData(), Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotVLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotVLines(const FString& Label, const TArray<float64> Values)",
@@ -502,7 +502,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotVLines(ToImGui(Label), Values.GetData(), Values.Num(), 0, sizeof(double));
+			ImPlot::PlotVLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(double));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotHLines(const FString& Label, const TArray<float32> Values)",
@@ -510,7 +510,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotHLines(ToImGui(Label), Values.GetData(), Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotHLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(FVector2D));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotHLines(const FString& Label, const TArray<float64> Values)",
@@ -518,7 +518,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotHLines(ToImGui(Label), Values.GetData(), Values.Num(), 0, sizeof(double));
+			ImPlot::PlotHLines(IMGUI_STR(Label), Values.GetData(), Values.Num(), 0, sizeof(double));
 		}
 	});
 	// void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, bool normalize=false, const char* label_fmt="%.1f", double angle0=90);
@@ -530,7 +530,7 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotDigital(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
+			ImPlot::PlotDigital(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2f));
 		}
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotDigital(const FString& Label, const TArray<FVector2D> Values)",
@@ -538,18 +538,18 @@ FAngelscriptBinds::FBind Bind_ImGui_PlotItems(FAngelscriptBinds::EOrder::Late, [
 	{
 		if (!Values.IsEmpty())
 		{
-			ImPlot::PlotDigital(ToImGui(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
+			ImPlot::PlotDigital(IMGUI_STR(Label), &Values[0].X, &Values[0].Y, Values.Num(), 0, sizeof(FVector2D));
 		}
 	});
 	// void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1));
 	FAngelscriptBinds::BindGlobalFunction("void PlotText(const FString& Text, float64 X, float64 Y, bool Vertical = false, const FVector2f& Offset = FVector2f(0, 0))",
 	[](const FString& Text, const double X, const double Y, const bool Vertical = false, const FVector2f& Offset = FVector2f(0, 0))
 	{
-		ImPlot::PlotText(ToImGui(Text), X, Y, Vertical, ToImGui(Offset));
+		ImPlot::PlotText(IMGUI_STR(Text), X, Y, Vertical, ToImGui(Offset));
 	});
 	FAngelscriptBinds::BindGlobalFunction("void PlotDummy(const FString& Label)",
 	[](const FString& Label)
 	{
-		ImPlot::PlotDummy(ToImGui(Label));
+		ImPlot::PlotDummy(IMGUI_STR(Label));
 	});
 });

--- a/Source/AngelscriptImGui/Private/Utilities/ImGuiScopedID.cpp
+++ b/Source/AngelscriptImGui/Private/Utilities/ImGuiScopedID.cpp
@@ -6,7 +6,7 @@
 
 FImGuiScopedID::FImGuiScopedID(const FString& StringID)
 {
-	ImGui::PushID(ToImGui(StringID));
+	ImGui::PushID(IMGUI_STR(StringID));
 	bHasPushedID = true;
 }
 

--- a/Source/AngelscriptImGui/Private/Utilities/ImGuiUtilities.h
+++ b/Source/AngelscriptImGui/Private/Utilities/ImGuiUtilities.h
@@ -11,6 +11,8 @@
 #include "AngelscriptDocs.h"
 #endif
 
+#define IMGUI_STR(Value) StringCast<ANSICHAR>(*Value).Get()
+
 FORCEINLINE ImVec2 ToImGui(const FVector2f& Vector)
 {
 	return ImVec2(Vector.X, Vector.Y);
@@ -34,11 +36,6 @@ FORCEINLINE ImVec4 ToImGui(const FVector4& Vector)
 FORCEINLINE ImVec4 ToImGui(const FColor& Color)
 {
 	return ToImGui(FVector4(Color));
-}
-
-FORCEINLINE const char* ToImGui(const FString& String)
-{
-	return StringCast<ANSICHAR>(*String).Get();
 }
 
 struct FImGuiEnumType final : public TAngelscriptPODType<int32>

--- a/Source/AngelscriptImGui/Private/Utilities/ImGuiUtilities.h
+++ b/Source/AngelscriptImGui/Private/Utilities/ImGuiUtilities.h
@@ -11,6 +11,8 @@
 #include "AngelscriptDocs.h"
 #endif
 
+#define IMPLOT_LATEST 1
+
 #define IMGUI_STR(Value) StringCast<ANSICHAR>(*Value).Get()
 
 FORCEINLINE ImVec2 ToImGui(const FVector2f& Vector)


### PR DESCRIPTION
StringCast is unsafe to use outside its scope. Return value gets cleared as soon as it exits the scope, leading to strings longer than 127 to become garbage and other potential string corruptions